### PR TITLE
Edited Gemfile and Schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
-    date (3.3.3)
+    date (3.3.4)
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
@@ -94,28 +94,14 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    digest (3.1.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    erubi (1.11.0)
-    globalid (1.0.0)
-      activesupport (>= 5.0)
-    i18n (1.12.0)
-=======
-=======
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
-<<<<<<< HEAD
->>>>>>> 91fc4f5 (bundled gems)
-=======
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
       concurrent-ruby (~> 1.0)
     importmap-rails (1.2.3)
       actionpack (>= 6.0.0)
@@ -133,20 +119,11 @@ GEM
       nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
       net-imap
       net-pop
       net-smtp
     mapbox-gl-rails (2.9.0)
       railties (>= 3.2)
-<<<<<<< HEAD
->>>>>>> 91fc4f5 (bundled gems)
-=======
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -163,35 +140,14 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-<<<<<<< HEAD
-<<<<<<< HEAD
-      timeout
-    nio4r (2.5.8)
-    nokogiri (1.13.8-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
-=======
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-linux)
->>>>>>> 91fc4f5 (bundled gems)
-      racc (~> 1.4)
-    orm_adapter (0.5.0)
-    public_suffix (5.0.0)
-    puma (5.6.5)
-=======
-    nio4r (2.5.9)
-    nokogiri (1.15.4-x86_64-linux)
-      racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.3)
     puma (5.6.7)
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)
@@ -211,14 +167,6 @@ GEM
       activesupport (= 7.0.3.1)
       bundler (>= 1.15.0)
       railties (= 7.0.3.1)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
-      nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
-=======
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -226,16 +174,6 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
->>>>>>> 91fc4f5 (bundled gems)
-=======
-    rails-dom-testing (2.2.0)
-      activesupport (>= 5.0.0)
-      minitest
-      nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.0)
-      loofah (~> 2.21)
-      nokogiri (~> 1.14)
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
     railties (7.0.3.1)
       actionpack (= 7.0.3.1)
       activesupport (= 7.0.3.1)
@@ -243,43 +181,19 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.5)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    rake (13.0.6)
-    redis (4.8.0)
-    regexp_parser (2.5.0)
-    reline (0.3.1)
-=======
-=======
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
     rake (13.1.0)
     rdoc (6.6.0)
       psych (>= 4.0.0)
     redis (4.8.1)
     regexp_parser (2.8.2)
     reline (0.3.9)
-<<<<<<< HEAD
->>>>>>> 91fc4f5 (bundled gems)
-=======
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
       io-console (~> 0.5)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-<<<<<<< HEAD
-    rexml (3.2.5)
-    rubyzip (2.3.2)
-<<<<<<< HEAD
-    selenium-webdriver (4.4.0)
-      childprocess (>= 0.5, < 5.0)
-=======
-    selenium-webdriver (4.10.0)
->>>>>>> 91fc4f5 (bundled gems)
-=======
     rexml (3.2.6)
     rubyzip (2.3.2)
     selenium-webdriver (4.10.0)
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -292,30 +206,12 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    strscan (3.0.4)
-    tailwindcss-rails (2.0.12-arm64-darwin)
-      railties (>= 6.0.0)
-    tailwindcss-rails (2.0.12-x86_64-darwin)
-      railties (>= 6.0.0)
-    tailwindcss-rails (2.0.12-x86_64-linux)
-=======
-    stringio (3.0.8)
-    tailwindcss-rails (2.0.32-x86_64-linux)
->>>>>>> 91fc4f5 (bundled gems)
-      railties (>= 6.0.0)
-    thor (1.2.1)
-    timeout (0.3.0)
-    turbo-rails (1.1.1)
-=======
     stringio (3.0.8)
     tailwindcss-rails (2.0.32-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.3.0)
-    timeout (0.4.0)
+    timeout (0.4.1)
     turbo-rails (1.5.0)
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
@@ -323,39 +219,17 @@ GEM
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-<<<<<<< HEAD
-    web-console (4.2.0)
-=======
     web-console (4.2.1)
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    webdrivers (5.0.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
-    websocket (1.2.9)
-    websocket-driver (0.7.5)
-=======
     webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0, < 4.11)
     websocket (1.2.10)
     websocket-driver (0.7.6)
->>>>>>> 91fc4f5 (bundled gems)
-=======
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
-    websocket (1.2.10)
-    websocket-driver (0.7.6)
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
@@ -373,14 +247,7 @@ DEPENDENCIES
   dotenv-rails
   importmap-rails
   jbuilder
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
   mapbox-gl-rails
->>>>>>> 91fc4f5 (bundled gems)
-=======
-  mapbox-gl-rails
->>>>>>> b18ff0818e7c15985bc315759282161a8f395a02
   mysql2 (~> 0.5)
   puma (~> 5.0)
   rails (~> 7.0.3, >= 7.0.3.1)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_06_014939) do
     t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "latitude"
+    t.float "longitude"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
There were lots of merge conflicts in the original Gemfile so I bundled installed a new Gemfile with the proper versions of Ruby, Rails, and any additional gems (mainly mapbox and devise). Schema did not have latitude and longitude attributes but that is autopopulated once you update the database after running a migration (i did not manually edit this file). 